### PR TITLE
Update page name on slack.js

### DIFF
--- a/src/pages/integrations/slack.js
+++ b/src/pages/integrations/slack.js
@@ -9,7 +9,7 @@ import thumbnailNoteWebhook from "../../../static/images/integration/slack-note-
 import thumbnailGuid1 from "../../../static/images/integration/slack-guid-1.png";
 import thumbnailGuid2 from "../../../static/images/integration/slack-guid-2.png";
 
-const AboutPage = () => (
+const SlackPage = () => (
     <Layout>
         <SEO title="Slack Integration"/>
 
@@ -98,4 +98,4 @@ const AboutPage = () => (
     </Layout>
 )
 
-export default AboutPage
+export default SlackPage


### PR DESCRIPTION
It seems the name used in this page component was not updated from where the code came from (AboutPage). I'm updating it to SlackPage :)